### PR TITLE
Update .github/workflows/generator-generic-ossf-slsa3-publish.yml

### DIFF
--- a/.github/workflows/generator-generic-ossf-slsa3-publish.yml
+++ b/.github/workflows/generator-generic-ossf-slsa3-publish.yml
@@ -52,8 +52,7 @@ jobs:
           # List the artifacts the provenance will refer to.
           files=$(ls artifact*)
           # Generate the subjects (base64 encoded).
-          echo "hashes=$(sha256sum $files | base64 -w0)" >> "${GITHUB_OUTPUT}"
-
+          echo "hashes=$(sha256sum "$files" | base64 -w0)" >> "${GITHUB_OUTPUT}"
   provenance:
     needs: [build]
     permissions:


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/generator-generic-ossf-slsa3-publish.yml` file. The change ensures that the `sha256sum` command properly handles filenames with spaces by enclosing the `$files` variable in double quotes.

* [`.github/workflows/generator-generic-ossf-slsa3-publish.yml`](diffhunk://#diff-98bd42f3b5e076be27172aad3387298cbca7505451064fb47b3a5c384bd0ca40L55-R55): Enclosed the `$files` variable in double quotes to handle filenames with spaces correctly.